### PR TITLE
Updated YouTubeImport plugin

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -300,7 +300,7 @@ Vimeo Import:
   url: https://github.com/UCSCLibrary/VimeoImport/releases/download/1.3/VimeoImport.zip
 YouTube Import:
   name: YouTubeImport
-  url: https://github.com/UCSCLibrary/YouTubeImport/releases/download/1.3/YouTubeImport.zip
+  url: https://github.com/Harvard-ATG/YouTubeImport/archive/refs/tags/1.4.zip
 Zotero Import:
   name: ZoteroImport
   url: https://github.com/omeka/plugin-ZoteroImport/releases/download/v2.2/ZoteroImport-2.2.zip

--- a/plugins.yml
+++ b/plugins.yml
@@ -300,7 +300,7 @@ Vimeo Import:
   url: https://github.com/UCSCLibrary/VimeoImport/releases/download/1.3/VimeoImport.zip
 YouTube Import:
   name: YouTubeImport
-  url: https://github.com/Harvard-ATG/YouTubeImport/archive/refs/tags/1.4.zip
+  url: https://github.com/Harvard-ATG/YouTubeImport/archive/refs/tags/1.4.1.zip
 Zotero Import:
   name: ZoteroImport
   url: https://github.com/omeka/plugin-ZoteroImport/releases/download/v2.2/ZoteroImport-2.2.zip

--- a/plugins/YouTubeImport/README.md
+++ b/plugins/YouTubeImport/README.md
@@ -3,5 +3,8 @@ This Omeka plugin adds the ability to import Youtube videos into Omeka as items 
 
 If you use this plugin, please take a moment to submit feedback about your experience, so we can keep making Omeka better: [User Survey](https://docs.google.com/forms/d/1cn-0S5RRJEQirXS8dCmBA_t-q2hrIw7rtQ9n9i_3e0c/viewform?usp=send_form)
 
+### API Key
+The plugin requires a free [YouTube Data API V3 key](https://developers.google.com/youtube/v3), which can be configured at `/admin/plugins/config?name=YouTubeImport`.
+
 ### Configuring Display Dimensions
 The dimensions of the embedded youtube video display default to 640px by 360px. These dimensions can be set in the plugin configuration page, at `/admin/plugins/config?name=YouTubeImport`. Setting these values can fix display problems on some themes. Keep in mind that you should include units in your width and height entries (e.g. "640px" or "100%").

--- a/plugins/YouTubeImport/YouTubeImportPlugin.php
+++ b/plugins/YouTubeImport/YouTubeImportPlugin.php
@@ -40,7 +40,7 @@ class YouTubeImportPlugin extends Omeka_Plugin_AbstractPlugin
     /**
      * @var array Options for the plugin.
      */
-    protected $_options = array('youtube_width'=>640,'youtube_height'=>360, 'youtube_apikey'=>'AIzaSyDI8ApsA7MBIK4M1Ubs9k4-Rk7_KOeYJ5w');
+    protected $_options = array('youtube_width'=>640,'youtube_height'=>360, 'youtube_apikey'=>'');
 
 	
     public function hookInitialize(){

--- a/plugins/YouTubeImport/YouTubeImportPlugin.php
+++ b/plugins/YouTubeImport/YouTubeImportPlugin.php
@@ -22,7 +22,8 @@ class YouTubeImportPlugin extends Omeka_Plugin_AbstractPlugin
         'public_head',
         'after_save_item',
         'config',
-        'config_form'
+        'config_form',
+	'initialize'
     );
 
     /**
@@ -39,8 +40,12 @@ class YouTubeImportPlugin extends Omeka_Plugin_AbstractPlugin
     /**
      * @var array Options for the plugin.
      */
-    protected $_options = array('youtube_width'=>640,'youtube_height'=>360);
+    protected $_options = array('youtube_width'=>640,'youtube_height'=>360, 'youtube_apikey'=>'AIzaSyDI8ApsA7MBIK4M1Ubs9k4-Rk7_KOeYJ5w');
 
+	
+    public function hookInitialize(){
+        require_once(dirname(__FILE__)."/helpers/import.php");
+    }
 
 
     public function hookAfterSaveItem($args){
@@ -63,7 +68,11 @@ class YouTubeImportPlugin extends Omeka_Plugin_AbstractPlugin
         //if there is not a current item record for this page, do nothing
         if(! $item = get_current_record('item', false))
             return $elementSets;
-
+	    
+	//if there is no "player" element installed, do nothing
+        if(!element_exists(ElementSet::ITEM_TYPE_NAME,'Player'))
+	        return $elementSets;
+		
         // if there is no youtube player on this item, do nothing
         if(!metadata($item,array('Item Type Metadata','Player')))
             return $elementSets;
@@ -98,13 +107,17 @@ class YouTubeImportPlugin extends Omeka_Plugin_AbstractPlugin
      *@return void
      */
     public function hookInstall(){
+        include_once(dirname(__FILE__).'/helpers/import.php');
         YoutubeImport_ImportHelper::CreateThumbnailElement;
+        YoutubeImport_ImportHelper::CreatePlayerElement;
     }
 
     public function hookUpgrade($oldVersion,$newVersion){
-        if($oldVersion < 1.2) {
+        include_once(dirname(__FILE__).'/helpers/import.php');
+        if(!element_exists(ElementSet::ITEM_TYPE_NAME,'Imported Thumbnail'))
             YoutubeImport_ImportHelper::CreateThumbnailElement;
-        }          
+	    if(!element_exists(ElementSet::ITEM_TYPE_NAME,'Player'))
+            YoutubeImport_ImportHelper::CreatePlayerElement;              
     }
 
     /**
@@ -202,6 +215,8 @@ class YouTubeImportPlugin extends Omeka_Plugin_AbstractPlugin
             set_option('youtube_width',$_REQUEST['youtube_width']);
         if(isset($_REQUEST['youtube_height']))
             set_option('youtube_height',$_REQUEST['youtube_height']);
+        if(isset($_REQUEST['youtube_apikey']))
+            set_option('youtube_apikey', $_REQUEST['youtube_apikey']);
     }
 
     public function hookConfigForm(){

--- a/plugins/YouTubeImport/forms/ImportForm.php
+++ b/plugins/YouTubeImport/forms/ImportForm.php
@@ -141,7 +141,7 @@ class Youtube_Form_Import extends Omeka_Form
 
         $client = new Google_Client();
         $client->setApplicationName("Omeka_Youtube_Import");
-        $client->setDeveloperKey(YoutubeImport_ImportHelper::$youtube_api_key);
+        $client->setDeveloperKey(YoutubeImport_ImportHelper::getApiKey());
   	
         try{
 	    $service = new Google_Service_YouTube($client);

--- a/plugins/YouTubeImport/forms/config_form.php
+++ b/plugins/YouTubeImport/forms/config_form.php
@@ -19,3 +19,14 @@
    <p class = "explanation">Enter the default height for display of videos imported from Youtube</p>
     </div>
 </div>
+
+<div class="field">
+    <div id="youtube-apikey-label" class="two columns alpha">
+        <label for="youtube_height"><?php echo __('YouTube API Key'); ?></label>
+    </div>
+    <div class="inputs five columns omega">
+   <?php echo get_view()->formText('youtube_apikey', get_option('youtube_apikey'), 
+        array()); ?>
+   <p class = "explanation">Enter a YouTube Data API V3 key, as YouTube rate limits the default key. See <a href="https://developers.google.com/youtube/v3">https://developers.google.com/youtube/v3</a>.</p>
+    </div>
+</div>

--- a/plugins/YouTubeImport/helpers/import.php
+++ b/plugins/YouTubeImport/helpers/import.php
@@ -15,9 +15,11 @@ class YoutubeImport_ImportHelper
 {
     
     /**
-     * @var string Youtube API key for this plugin
+     * @return $string Youtube API key for this plugin
      */
-    public static $youtube_api_key = 'AIzaSyDI8ApsA7MBIK4M1Ubs9k4-Rk7_KOeYJ5w';
+    public function getApiKey(){
+        return get_option('youtube_apikey');
+    }
     
     /**
      * @var string Google app name associated with this plugin


### PR DESCRIPTION
This PR updates the YouTubeImport plugin. Switched from the [official repository](https://github.com/UCSCLibrary/YouTubeImport) to our [fork](https://github.com/Harvard-ATG/YouTubeImport), which adds config options so users can configure the API key.

@ColeDCrawford FYI