### PR TITLE
updated course tools plugin

### DIFF
--- a/all_plugins_info.yml
+++ b/all_plugins_info.yml
@@ -264,7 +264,7 @@ Corrections:
 Course Tools:
   available: true
   description: Adds custmizable student role
-  download_url: https://github.com/jaguillette/omeka-plugin-CourseTools/archive/refs/tags/v1.0.zip
+  download_url: https://github.com/jaguillette/omeka-plugin-CourseTools/archive/refs/tags/v1.1.zip
   folder_name: CourseTools
   name: Course Tools
   note: Default plugin on our instance

--- a/plugins/CourseTools/CourseToolsPlugin.php
+++ b/plugins/CourseTools/CourseToolsPlugin.php
@@ -48,9 +48,13 @@ class CourseToolsPlugin extends Omeka_Plugin_AbstractPlugin
 
     # Allow students to edit own files, autocomplete tags, access additional elements.
     # These permissions don't fit into the defined permissions, but are needed.
-    $acl->allow('student','Files','editSelf');
-    $acl->allow('student','Tags',array('autocomplete'));
+    $acl->allow('student', 'Files', 'editSelf');
+    $acl->allow('student', 'Tags', array('autocomplete'));
     $acl->allow('student', 'Elements', 'element-form');
+    # Allow students access to cover images if Exhibit Builder is installed
+    if ($acl->has('ExhibitBuilder_Files')) {
+      $acl->allow('student', 'ExhibitBuilder_Files', 'cover-image');
+    }
 
     # Set student permissions on Simple Pages
     if ($acl->has('SimplePages_Index') && $acl->has('SimplePages_Page')) {


### PR DESCRIPTION
This applies an update from the course tools plugin to address a permissions error when setting a cover image on an exhibit. Tested on dev and it resolved the issue.