### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ After adding that configuration, run `python refresh_cache.py plugins|themes`, s
 
 After refreshing the cache, you can look over changes to this repo, make sure everything looks okay, and submit a PR to add the new addon.
 
+The new addon will not be available to Omeka sites until the `ansible/vars_files/plugins.yml` file is updated to include the new plugin as an available option.
+
 ## Update addon info from omeka.org
 
 Updating addon info involves pulling information from Omeka Classic's plugins and themes repositories. The `update_info.py` script scrapes these pages and updates the `all_plugins_info.yml` and `all_themes_info.yml` files with new addons and new links for existing addons. It doesn't assume that the list on Omeka is comprehensive, so it won't remove anything that it doesn't find on the omeka.org pages. This also preserves added notes and availability flags.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ After adding that configuration, run `python refresh_cache.py plugins|themes`, s
 
 After refreshing the cache, you can look over changes to this repo, make sure everything looks okay, and submit a PR to add the new addon.
 
-The new addon will not be available to Omeka sites until the `ansible/vars_files/plugins.yml` file is updated to include the new plugin as an available option.
+The new addon will not be available to Omeka sites until the appropriate `ansible/vars_files/plugins.yml` or `ansible/vars_files/themes.yml` file is updated to include the new plugin or theme as an available option.
 
 ## Update addon info from omeka.org
 


### PR DESCRIPTION
Updating the readme to help us in the future, since I just went in to add a new plugin and forgot a step to enable it. This just adds a note that you need to update the ansible config in the Omeka deployment repo in order for a new plugin or theme to be available.